### PR TITLE
Add unsupervised mode

### DIFF
--- a/src-tauri/src/ipc/bot_config.rs
+++ b/src-tauri/src/ipc/bot_config.rs
@@ -53,6 +53,8 @@ pub struct FarmingConfig {
     use_attack_skills: Option<bool>,
     /// Whether the bot will try to stay in the area it started in
     stay_in_area: Option<bool>,
+    /// Whether the bot should try to level in a fully unsupervised way
+    unsupervised: Option<bool>,
     /// Slot configuration
     slots: Option<[Slot; 10]>,
     /// Disable farming
@@ -70,6 +72,10 @@ impl FarmingConfig {
 
     pub fn should_stay_in_area(&self) -> bool {
         self.stay_in_area.unwrap_or(false)
+    }
+
+    pub fn is_unsupervised(&self) -> bool {
+        self.unsupervised.unwrap_or(false)
     }
 
     pub fn slots(&self) -> Vec<Slot> {

--- a/src-tauri/src/utils/timer.rs
+++ b/src-tauri/src/utils/timer.rs
@@ -28,6 +28,9 @@ impl Timer {
         if *self.is_silenced.borrow() {
             return;
         }
+        if std::env::var("NEUZ_TIMERS").is_err() {
+            return;
+        }
         println!(
             "[{} {}${}] took {:?}",
             self.label,
@@ -47,6 +50,9 @@ impl Timer {
 
     pub fn report(&self) {
         if *self.is_silenced.borrow() {
+            return;
+        }
+        if std::env::var("NEUZ_TIMERS").is_err() {
             return;
         }
         println!("[{}] took {:?}", self.label, self.elapsed());

--- a/src/components/config/FarmingConfig.tsx
+++ b/src/components/config/FarmingConfig.tsx
@@ -42,6 +42,10 @@ const FarmingConfig = ({ className, config, onChange }: Props) => {
                     <BooleanSlider value={config.stay_in_area ?? false} onChange={value => onChange?.({ ...config, stay_in_area: value })} />
                     <ConfigLabel name="Stay in Area" helpText="The bot will try to wait in the area and not move around too much." />
                 </ConfigRow>
+                <ConfigRow>
+                    <BooleanSlider value={config.unsupervised ?? false} onChange={value => onChange?.({ ...config, unsupervised: value })} />
+                    <ConfigLabel name="Unsupervised (Experimental)" helpText="The bot will try extra hard not to move. Makes farming a bit slower, but also safer." />
+                </ConfigRow>
             </ConfigPanel>
         </>
     )

--- a/src/models/BotConfig.tsx
+++ b/src/models/BotConfig.tsx
@@ -14,6 +14,7 @@ export type FarmingConfigModel = Partial<{
     on_demand_pet: boolean,
     use_attack_skills: boolean,
     stay_in_area: boolean,
+    unsupervised: boolean,
     slots: SlotBarModel,
 }>
 


### PR DESCRIPTION
Unsupervised mode tries extra hard not to move and waits until mobs have despawned after each kill.

Pros:
- Should be more sustainable when leveling over longer periods of time
- Should be viable for extended periods of afk leveling

Cons:
- Less efficient, longer wait-time between kills
- More easily detectable, no randomized movement except rotation