### PR TITLE
Added 2 slot QOL features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Date format: `DD/MM/YYYY`
 [@slyker]: https://github.com/slyker
 <!-- /maintainers -->
 
+**0.16.3**
+> Released on 24.3.2023
+- Support
+  - Fixed issue where buffs would often be skipped.
+- Misc
+  - Added Red/Green outline to indicate if a slot is enabled/disabled
+  - You can now Shift+Click any slot to immediatly enable/disable it without having to open the menu for each of them.
+
 **0.16.2**
 > Released on 12.11.2022
 - Support

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,8 @@ Contributions:
 
 Contributions:
 - Pill usage in farming behavior
+
+## [Credit-Score](https://github.com/Credit-Score)
+
+Contributions:
+- Support buff fix + small QOL feature.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Neuz",
-    "version": "0.16.2"
+    "version": "0.16.3"
   },
   "tauri": {
     "allowlist": {
@@ -17,7 +17,7 @@
     "bundle": {
       "active": true,
       "category": "Productivity",
-      "copyright": "2022 MadrigalStreetCartel",
+      "copyright": "2023 MadrigalStreetCartel",
       "deb": {
         "depends": []
       },

--- a/src/components/Slot.tsx
+++ b/src/components/Slot.tsx
@@ -21,7 +21,9 @@ const Slot = ({ className, type = 'Unused', index, onChange, toggleSlotModal, in
     const useIcon = symbolOrIcon.startsWith('data:') || symbolOrIcon.includes('static');
     var styleInline = {border: '1px solid hsl(48,58%,43%)'};
     if(slot){
-        styleInline = slot.slot_enabled === true ? {border: '1px solid green'} : {border: '1px solid red'};
+        if(slot.slot_type != "Unused"){
+            styleInline = slot.slot_enabled === true ? {border: '1px solid green'} : {border: '1px solid red'};
+        }
     }
     // const styleClassName = slot.slot_enabled === true ? 'enabled_slot' : 'disabled_slot'
     return (

--- a/src/components/Slot.tsx
+++ b/src/components/Slot.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { SlotType, slotTypes, SLOT_SIZE_PX, translateDesc, translateType } from '../models/BotConfig'
+import { SlotModel, SlotType, slotTypes, SLOT_SIZE_PX, translateDesc, translateType } from '../models/BotConfig'
 
 type Props = {
     className?: string,
@@ -8,20 +8,25 @@ type Props = {
     index: number,
     indexName: string,
     onChange?: (type: SlotType) => void,
-    toggleSlotModal: () => void,
+    toggleSlotModal: (event:any,targetSlot: SlotModel) => void,
+    slot: SlotModel,
 }
 
-const Slot = ({ className, type = 'Unused', index, onChange, toggleSlotModal, indexName }: Props) => {
+const Slot = ({ className, type = 'Unused', index, onChange, toggleSlotModal, indexName,slot }: Props) => {
     const handleChange = () => {
         const nextType: SlotType = slotTypes[(slotTypes.indexOf(type) + 1) % slotTypes.length];
         onChange?.(nextType)
     }
     const symbolOrIcon = translateType(type)
     const useIcon = symbolOrIcon.startsWith('data:') || symbolOrIcon.includes('static');
-
+    var styleInline = {border: '1px solid hsl(48,58%,43%)'};
+    if(slot){
+        styleInline = slot.slot_enabled === true ? {border: '1px solid green'} : {border: '1px solid red'};
+    }
+    // const styleClassName = slot.slot_enabled === true ? 'enabled_slot' : 'disabled_slot'
     return (
 
-        <div className={className} onClick={toggleSlotModal} >
+        <div style={styleInline} className={className} onClick={(e) => toggleSlotModal(e,slot)} >
             <div className="index">{indexName}</div>
             <div className='slot' onClick={handleChange}>
                 {useIcon && (
@@ -62,6 +67,14 @@ export default styled(Slot)`
         height:100%;
         width: 100%;
         text-align: center;
+    }
+
+    & .enabled_slot {
+        border: 1px solid green;
+    }
+
+    & .disabled_slot {
+        border: 1px solid red;
     }
 
     & .index {

--- a/src/components/SlotBar.tsx
+++ b/src/components/SlotBar.tsx
@@ -19,9 +19,14 @@ const SlotBar = ({ className, config, botMode, onChange }: Props) => {
     const { isShown, toggle } = useModal();
     const [currentSlotId, setCurrentSlotId] = useState(-1)
     const [currentBarIndex, setCurrentBarIndex] = useState(0)
-    const toogleSlot = (id: number) => {
-        setCurrentSlotId(id)
-        toggle()
+    const toogleSlot = (id: number, event: any,targetSlot: SlotModel ) => {
+        if(event.shiftKey){
+            targetSlot.slot_enabled = !targetSlot.slot_enabled;
+            handleSlotChange(currentBarIndex, id, targetSlot);
+        }else{
+            setCurrentSlotId(id)
+            toggle()
+        }
     }
     let slots = config.slot_bars ?? createSlotBars()
 
@@ -43,7 +48,7 @@ const SlotBar = ({ className, config, botMode, onChange }: Props) => {
 
                 <div className="slots">
                     {slots[currentBarIndex].slots.map((slot, index) =>  (
-                        <Slot key={index} type={slot.slot_type} index={index} toggleSlotModal={() => toogleSlot(index)} indexName={index +""} />
+                        <Slot key={index} type={slot.slot_type} index={index} toggleSlotModal={(event,targetSlot) => toogleSlot(index,event,targetSlot)} indexName={index +""} slot={slots[currentBarIndex].slots[index]} />
 
                     ))}
                     <div className="slotIndexChanger">


### PR DESCRIPTION
1. Adds red/green outline to each slot in the overall display, allowing you to quickly see which slots are enabled/disabled.

2. Adds shift+click functionality to each individual slot. Normal click functionality is intact, but if you shift+click a slot it will enable/disable it. (Which state it is now in is clearly visible due to change #1 I made.)

Tested myself and it has worked without any issues thus far.