### PR TITLE
Fix buffs being skipped constantly

### DIFF
--- a/src-tauri/src/behavior/support_behavior.rs
+++ b/src-tauri/src/behavior/support_behavior.rs
@@ -157,6 +157,10 @@ impl<'a> SupportBehavior<'_> {
             if send {
                 //slog::debug!(self.logger, "Slot usage"; "slot_type" => slot_type.to_string(), "value" => threshold);
                 self.send_slot(slot_index);
+                if slot_type == SlotType::HealSkill {
+                    // Set last buff usage to now so that a buff doesn't try and happen immediately after a heal
+                    self.last_buff_usage = Instant::now();
+                }
             }
 
             return Some(slot_index);


### PR DESCRIPTION
Accounts for when each heal happens to ensure buffs are not constantly skipped by heals happening when it was also trying to buff.