### PR TITLE
Improve stats modal UI

### DIFF
--- a/src/MissionControl.tsx
+++ b/src/MissionControl.tsx
@@ -214,12 +214,99 @@ export default styled(MissionControl)`
     }
 
     & .stats {
-        & .row {
-            color: white;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.25rem 0;
+
+        & .stats__state {
             display: flex;
-            align-items: center;
-            justify-content: space-around;
-            gap: 3rem;
+            justify-content: center;
+            margin-bottom: 0.25rem;
+        }
+
+        & .stats__badge {
+            display: inline-block;
+            padding: 0.2rem 0.75rem;
+            border-radius: 1rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: white;
+            background: hsla(0, 0%, 50%, 0.4);
+
+            &--searching {
+                background: hsla(45, 100%, 45%, 0.5);
+                box-shadow: 0 0 8px hsla(45, 100%, 50%, 0.3);
+            }
+            &--fighting {
+                background: hsla(0, 80%, 45%, 0.5);
+                box-shadow: 0 0 8px hsla(0, 80%, 50%, 0.3);
+            }
+            &--dead {
+                background: hsla(0, 0%, 30%, 0.6);
+            }
+            &--idle {
+                background: hsla(210, 30%, 40%, 0.4);
+            }
+            &--ready {
+                background: hsla(140, 60%, 35%, 0.5);
+                box-shadow: 0 0 8px hsla(140, 60%, 40%, 0.3);
+            }
+        }
+
+        & .stats__section {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+
+        & .stats__section-title {
+            font-size: 0.65rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: hsla(0, 0%, 100%, 0.4);
+            border-bottom: 1px solid hsla(0, 0%, 100%, 0.1);
+            padding-bottom: 0.2rem;
+        }
+
+        & .stats__grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.4rem;
+        }
+
+        & .stats__card {
+            display: flex;
+            flex-direction: column;
+            gap: 0.15rem;
+            padding: 0.4rem 0.5rem;
+            background: hsla(0, 0%, 100%, 0.05);
+            border-radius: 0.3rem;
+            border: 1px solid hsla(0, 0%, 100%, 0.07);
+        }
+
+        & .stats__label {
+            font-size: 0.6rem;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: hsla(0, 0%, 100%, 0.45);
+        }
+
+        & .stats__value {
+            font-size: 1.1rem;
+            font-weight: 700;
+            color: white;
+
+            &--time {
+                font-size: 0.85rem;
+                font-weight: 600;
+                font-family: monospace;
+                letter-spacing: 0.02em;
+            }
         }
     }
 

--- a/src/components/behaviors/FarmingConfig.tsx
+++ b/src/components/behaviors/FarmingConfig.tsx
@@ -250,26 +250,60 @@ const FarmingConfig = ({ className, info, config, onChange, botStopWatch, botSta
             }/>
 
             <Modal isShowing={statsModal.isShown} hide={statsModal.close}
-            title={<h4>Stats - State: { botState }</h4>} body={
+            title={<h4>Stats</h4>} body={
                 <div className="stats">
-                    <div className="row">
-                        <div>Kills : {info?.enemy_kill_count}</div>
+                    <div className="stats__state">
+                        <span className={`stats__badge stats__badge--${botState}`}>{botState}</span>
                     </div>
-                    <div className="row">
-                        <div>Botting time: {botStopWatch?.toString()}</div>
+
+                    <div className="stats__section">
+                        <div className="stats__section-title">Session</div>
+                        <div className="stats__grid">
+                            <div className="stats__card">
+                                <span className="stats__label">Kills</span>
+                                <span className="stats__value">{info?.enemy_kill_count ?? 0}</span>
+                            </div>
+                            <div className="stats__card">
+                                <span className="stats__label">Botting Time</span>
+                                <span className="stats__value stats__value--time">{botStopWatch?.toString() ?? "00:00:00:000"}</span>
+                            </div>
+                        </div>
                     </div>
-                    <div className="row">
-                        <div>Last search time: {searchMobStopWatch}</div>
+
+                    <div className="stats__section">
+                        <div className="stats__section-title">Last Kill</div>
+                        <div className="stats__grid">
+                            <div className="stats__card">
+                                <span className="stats__label">Search Time</span>
+                                <span className="stats__value stats__value--time">{searchMobStopWatch}</span>
+                            </div>
+                            <div className="stats__card">
+                                <span className="stats__label">Fight Time</span>
+                                <span className="stats__value stats__value--time">{fightStopWatch}</span>
+                            </div>
+                        </div>
                     </div>
-                    <div className="row">
-                        <div>Last fight time: {fightStopWatch}</div>
-                    </div>
-                    <div className="row">
-                        <div>Last kill stats(approx): {info?.kill_min_avg}/min | {info?.kill_hour_avg}/hour</div>
-                    </div>
-                    <div className="row">
-                        <div>Global kills stats(approx): {globalKPM === "NaN" || globalKPM === "Infinity" ? 0 : globalKPM}/min
-                        | {globalKPH === "NaN" || globalKPH === "Infinity" ? 0 : globalKPH}/hour</div>
+
+                    <div className="stats__section">
+                        <div className="stats__section-title">Performance</div>
+                        <div className="stats__grid">
+                            <div className="stats__card">
+                                <span className="stats__label">Last KPM</span>
+                                <span className="stats__value">{info?.kill_min_avg?.toFixed(2) ?? 0}</span>
+                            </div>
+                            <div className="stats__card">
+                                <span className="stats__label">Last KPH</span>
+                                <span className="stats__value">{info?.kill_hour_avg?.toFixed(2) ?? 0}</span>
+                            </div>
+                            <div className="stats__card">
+                                <span className="stats__label">Global KPM</span>
+                                <span className="stats__value">{globalKPM === "NaN" || globalKPM === "Infinity" ? "0.00" : globalKPM}</span>
+                            </div>
+                            <div className="stats__card">
+                                <span className="stats__label">Global KPH</span>
+                                <span className="stats__value">{globalKPH === "NaN" || globalKPH === "Infinity" ? "0.00" : globalKPH}</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             }/>


### PR DESCRIPTION
## Summary
- Redesigned the farming stats modal from plain text rows to a structured card-based dashboard
- Added color-coded state badge (searching, fighting, dead, idle, ready)
- Organized stats into 3 sections: Session, Last Kill, and Performance
- Grid layout with styled cards, section titles, and proper visual hierarchy
- Monospace font for time values, bold values with subtle labels

## Test plan
- [ ] Open the bot in farming mode
- [ ] Click "Stats" button to open the stats modal
- [ ] Verify all stats display correctly (kills, times, KPM/KPH)
- [ ] Verify state badge changes color based on bot state

🤖 Generated with [Claude Code](https://claude.com/claude-code)